### PR TITLE
feat : global variable test code added

### DIFF
--- a/packages/kbd-txt/package.json
+++ b/packages/kbd-txt/package.json
@@ -34,6 +34,7 @@
     "clean:ts": "tsc --build --clean",
     "pretest": "yarn build:ts",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "prepare": "husky install",
     "format": "prettier src/**/* --write --ignore-unknown",
     "clean": "rm -rf ./dist ./dist-test",

--- a/packages/kbd-txt/test.js
+++ b/packages/kbd-txt/test.js
@@ -6,6 +6,53 @@ const {
 } = require('./dist-test/index.js');
 const utils = require('./dist-test/utils.js');
 
+describe('platform', () => {
+  describe.each([
+    'global.navigator.userAgentData.platform',
+    'global.navigator.platform',
+  ])('%s 를 사용하는 경우', (navigatorProperty) => {
+    beforeEach(() => {
+      global.navigator = {
+        userAgentData: { platform: undefined },
+        platform: undefined,
+      };
+    });
+
+    test.each(['MacIntel', 'Ipod', 'Iphone', 'Ipad', 'MacPPC', 'Mac68K'])(
+      'IOS(%s) 경우 true 를 반환',
+      (platform) => {
+        global.navigator = /userAgentData/.test(navigatorProperty)
+          ? { userAgentData: { platform } }
+          : { platform };
+
+        expect(utils.isIOS()).toBe(true);
+      },
+    );
+
+    test.each(['Win32', 'Win64', 'Windows', 'WinCE', 'Linux', 'Android'])(
+      '다른 OS(%s)의 경우 false 를 반환',
+      (platform) => {
+        global.navigator = /userAgentData/.test(navigatorProperty)
+          ? { userAgentData: { platform } }
+          : { platform };
+
+        expect(utils.isIOS()).toBe(false);
+      },
+    );
+
+    test.each([null, undefined])(
+      'platform이 없는 경우 false 를 반환',
+      (platform) => {
+        global.navigator = /userAgentData/.test(navigatorProperty)
+          ? { userAgentData: { platform } }
+          : { platform };
+
+        expect(utils.isIOS()).toBe(false);
+      },
+    );
+  });
+});
+
 describe('parseToToken', () => {
   test('platform이 Mac일 경우, $mod가 meta로 변환된다.', () => {
     jest.spyOn(utils, 'isIOS').mockImplementation(() => true);


### PR DESCRIPTION
Ciao! 
I came in to make a test code, but the test is already done well. 

so i just added some code to make 100% coverage



chagne
- global variable test code added
- npm script ( test:coverage ) added

kinds of platform ref
- [chromium platforms](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/navigator_id.cc;l=64;drc=703d3c472cf27470dad21a3f2c8972aca3732cd6)
- [Various platforms](https://stackoverflow.com/questions/19877924/what-is-the-list-of-possible-values-for-navigator-platform-as-of-today)

before
![image](https://user-images.githubusercontent.com/5876149/214864507-3b664795-d4e0-4121-8968-8ee487d6e5b9.png)

after
![image](https://user-images.githubusercontent.com/5876149/214864563-47ba8da2-b3cb-47b1-ae59-b589748f4f37.png)

( Nevertheless, It is not meaning that code is safe. 🤗 )